### PR TITLE
Update Project links and remove a section

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,13 +128,6 @@
                   <p>A portal to unify developers on a single app. It will support projects, invites, and more!</p>
                 </div>
               </div>
-              <div class="probootstrap-cell reverse probootstrap-animate" data-animate-effect="fadeIn">
-                <div class="image" style="background-image: url(img/square_sec.jpg);"></div>
-                <div class="text text-center">
-                  <h3><a href="https://github.com/CityOfZion/neo"><b>Security review</b></a></h3>
-                  <p>A crucial and never-ending process. We are always looking for contributions!</p>
-                </div>
-              </div>
               <div class="probootstrap-cell probootstrap-animate" data-animate-effect="fadeIn">
                 <div class="image" style="background-image: url(img/square_trello.jpg);"></div>
                 <div class="text text-center">

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
               <div class="probootstrap-cell reverse probootstrap-animate" data-animate-effect="fadeIn">
                 <div class="image" style="background-image: url(img/square_neoscan.jpg);"></div>
                 <div class="text text-center">
-                  <h3><a href="https://explorer.cityofzion.io"><b>NEOScan</b></a></h3>
+                  <h3><a href="https://github.com/CityOfZion/neo-scan"><b>NEOScan</b></a></h3>
                   <p>A high-performance block explorer and API laying the foundation for other projects.</p>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
               <div class="probootstrap-cell probootstrap-animate" data-animate-effect="fadeIn">
                 <div class="image" style="background-image: url(img/square_neon.jpg);"></div>
                 <div class="text text-center">
-                  <h3><a href="https://www.neonwallet.com/"><b>NEON wallet</b></a></h3>
+                  <h3><a href="http://www.neonwallet.com/"><b>NEON wallet</b></a></h3>
                   <p>An Electron-based light wallet (no need for chain copy nor VM) for Windows, OSX, and Linux users.</p>
                 </div>
               </div>


### PR DESCRIPTION
This PR cleans up the Projects section on the home page.

* Switch to http:// (instead of https://) for the NEON wallet page URL, as the certificate is not currently valid

(I'd imagine the preference is for the certificate to be valid though, if cost is an issue, CloudFlare is a free HTTPS proxy.)

* NeoScan project pointed to a non-existant site, just changed it to the GitHub repro.

* Removed the Security Review project, as the repro it linked to is now hidden/removed.