### PR TITLE
Add "About" to COZ dApp competition page

### DIFF
--- a/dapps/1.html
+++ b/dapps/1.html
@@ -89,6 +89,9 @@
 				<h2 class="yellow-headline">Support</h2>
 				<p class="body-copy">For the development phase the City of Zion council will provide testnet NEO and GAS for developers and teams on our Slack. The winning participants are invited to join us at the #develop channel to help further their progress.</p>
 				
+				<h2 class="yellow-headline">About</h2>
+				<p class="body-copy">City of Zion (COZ) is a global community of open source enthusiasts for the NEO blockchain, with the shared goal of helping NEO achieve its full potential. See our <a href="https://github.com/CityOfZion/governance">governance</a> page for more information about our community. Our name comes from the last human city in the Matrix films.</p>
+				
 				<p class="good-luck">Good Luck!</p>
 				<p class="signoff">City of Zion Council</p>
 			</div>


### PR DESCRIPTION
In general, I think it's good that people unfamiliar with the Neo community get a line or two about who we are. More specifically, the "Zion" name often confuses people who do not know about Neo (even some who do), so if I want to share this with an organization like the Stanford alumni network, probably want some clarity there. 